### PR TITLE
Error process

### DIFF
--- a/example-queries.yml
+++ b/example-queries.yml
@@ -39,6 +39,10 @@
     # of expected updates and the required granularity of changes.
     interval: 1h
 
+    # error value, default is null
+    # if not null, when query has error, will use this value to indicate an error has occured
+    #error-value: '-1'
+
 # For faceted metrics provide the name of the metric-column in config, and return a resultset of multiple columns and rows
 - sales_by_country:
     # Name of the driver to use.

--- a/example-queries.yml
+++ b/example-queries.yml
@@ -39,9 +39,9 @@
     # of expected updates and the required granularity of changes.
     interval: 1h
 
-    # error value, default is null
+    # value on error, default is null
     # if not null, when query has error, will use this value to indicate an error has occured
-    #error-value: '-1'
+    #value-on-error: '-1'
 
 # For faceted metrics provide the name of the metric-column in config, and return a resultset of multiple columns and rows
 - sales_by_country:

--- a/main.go
+++ b/main.go
@@ -26,15 +26,15 @@ var (
 
 // Query defines a SQL statement and parameters as well as configuration for the monitoring behavior
 type Query struct {
-	Name       string
-	Driver     string
-	Connection map[string]interface{}
-	SQL        string
-	Params     map[string]interface{}
-	Interval   time.Duration
-	Timeout    time.Duration
-	DataField  string `yaml:"data-field"`
-    ErrorValue string `yaml:"error-value"`
+	Name         string
+	Driver       string
+	Connection   map[string]interface{}
+	SQL          string
+	Params       map[string]interface{}
+	Interval     time.Duration
+	Timeout      time.Duration
+	DataField    string `yaml:"data-field"`
+	ValueOnError string `yaml:"value-on-error"`
 }
 type QueryList []*Query
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ type Query struct {
 	Interval   time.Duration
 	Timeout    time.Duration
 	DataField  string `yaml:"data-field"`
+    ErrorValue string `yaml:"error-value"`
 }
 type QueryList []*Query
 


### PR DESCRIPTION
Add error process logic, which can be used as a simple and general database health checker. 
Add `error-value` in `queries.yml`. The default error value is null.
if not null, when query has error, we will use this value to indicate an error has occured.