### PR TITLE
Issue #27: new -lax option tolerates invalid files in queryDir

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -235,9 +235,24 @@ func Test_loadNonExistingFiles(t *testing.T) {
 		return
 	}
 
-	_, err = loadQueriesInDir(file, newConfig())
+	_, err = loadQueriesInDir(file, newConfig(), false)
 	if err == nil {
 		t.Errorf("No errors even if query directory [%s] does not exist!", file)
 		return
+	}
+}
+
+func Test_allowBrokenQueryFileInDir(t *testing.T) {
+	//config should allow loading queries from a directory that contains invalid files; bad files should not
+	//stop good queries from running
+
+	//load a directory having one good and one bad query
+	q, err := loadQueriesInDir("test-resources/config-test/one-good-query", newConfig(), true)
+	//expect no error and 1 query
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(q) != 1 {
+		t.Fatal(len(q))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -16,12 +16,13 @@ import (
 func main() {
 	log.Println("prometheus-sql starting up...")
 	var (
-		host        string
-		port        int
-		service     string
-		queriesFile string
-		queryDir    string
-		confFile    string
+		host                         string
+		port                         int
+		service                      string
+		queriesFile                  string
+		queryDir                     string
+		confFile                     string
+		tolerateInvalidQueryDirFiles bool
 	)
 
 	flag.StringVar(&host, "host", DefaultHost, "Host of the service.")
@@ -30,6 +31,7 @@ func main() {
 	flag.StringVar(&queriesFile, "queries", DefaultQueriesFile, "Path to file containing queries.")
 	flag.StringVar(&queryDir, "queryDir", DefaultQueriesDir, "Path to directory containing queries.")
 	flag.StringVar(&confFile, "config", DefaultConfFile, "Configuration file to define common data sources etc.")
+	flag.BoolVar(&tolerateInvalidQueryDirFiles, "lax", DefaultTolerateInvalidQueryDirFiles, "Tolerate invalid files in queryDir")
 
 	flag.Parse()
 
@@ -58,9 +60,9 @@ func main() {
 			log.Fatal(err)
 		}
 	}
-	
+
 	if queryDir != "" {
-		queries, err = loadQueriesInDir(queryDir, config)
+		queries, err = loadQueriesInDir(queryDir, config, tolerateInvalidQueryDirFiles)
 	} else {
 		queries, err = loadQueryConfig(queriesFile, config)
 	}

--- a/test-resources/config-test/one-good-query/bad.yml
+++ b/test-resources/config-test/one-good-query/bad.yml
@@ -1,0 +1,1 @@
+invalid: config

--- a/test-resources/config-test/one-good-query/good.yml
+++ b/test-resources/config-test/one-good-query/good.yml
@@ -1,0 +1,19 @@
+- storage_used_tb:
+    driver: mysql
+
+    connection:
+        host: 172.17.0.1
+        port: 3306
+        user: user
+        password: password
+        database: db1
+
+    sql: >
+        select
+          something, metric
+        from
+          somewhere;;
+
+    interval: 10m
+
+    data-field: metric


### PR DESCRIPTION
Existing functionality is unchanged unless new boolean option (-lax) is used.

When -lax is specified, invalid files in queryDir don't cause program termination. Instead they just cause a log warning, allowing continuation to subsequent files.

I've added a test, and some test assets for this too.