### PR TITLE
Register metrics before unregistering them

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -43,7 +43,7 @@ func (w *Worker) SetMetrics(recs records) {
 		return
 	}
 
-	w.result.RemoveMissingMetrics(list)
+	w.result.RegisterMetrics(list)
 }
 
 func (w *Worker) Fetch(url string) (records, error) {


### PR DESCRIPTION
This avoids races when metrics change label between two scrapes (or an
error value is set).

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>